### PR TITLE
log4j zero day fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ COPY target/scala-2.12/*.jar /app/
 
 WORKDIR /app
 
-CMD java -jar ./AuthzVerifyProxy.jar
 # override CMD from your orchestrator with appropriate jvm args, -Xms1024m -Xmx15360m etc...
+CMD java -Dlog4j2.formatMsgNoLookups=true -jar ./AuthzVerifyProxy.jar


### PR DESCRIPTION
CVE-2021-44228 https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228